### PR TITLE
Added download_source to use any source location 

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,6 +12,11 @@
 #   <https://mathias-kettner.de/check_mk_download.html>, e.g. '1.2.4p5-1'
 #   *MUST*
 #
+# [*download_source*]
+#   Source to download check_mk-agent package.
+#   defaults to _http://mathias-kettner.de/download_
+# 
+#
 # [*package_name*]
 #   Name of Check MK Package override
 #   depends on ::osfamily
@@ -70,6 +75,7 @@
 class omd::client (
   $check_mk_version,
   $package_name     = $omd::client::params::package_name,
+  $download_package = $moni::client::params::download_package,
   $download_package = $omd::client::params::download_package,
   $logwatch_install = $omd::client::params::logwatch_install,
   $xinetd_disable   = $omd::client::params::xinetd_disable,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -16,7 +16,6 @@
 #   Source to download check_mk-agent package.
 #   defaults to _http://mathias-kettner.de/download_
 # 
-#
 # [*package_name*]
 #   Name of Check MK Package override
 #   depends on ::osfamily
@@ -76,7 +75,7 @@ class omd::client (
   $check_mk_version,
   $package_name     = $omd::client::params::package_name,
   $download_package = $moni::client::params::download_package,
-  $download_package = $omd::client::params::download_package,
+  $download_source  = $omd::client::params::download_source,
   $logwatch_install = $omd::client::params::logwatch_install,
   $xinetd_disable   = $omd::client::params::xinetd_disable,
   $check_only_from  = $omd::client::params::check_only_from,
@@ -89,6 +88,7 @@ class omd::client (
   validate_string($check_mk_version)
   validate_string($package_name)
   validate_bool($download_package)
+  validate_bool($download_source)
   validate_re($xinetd_disable, ['^yes$','^no$'])
   validate_string($check_only_from)
   validate_absolute_path($check_agent)

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -2,7 +2,7 @@
 class omd::client::install {
 
   if $omd::client::download_package {
-    $download_source = 'http://mathias-kettner.de/download'
+    $download_source = "${moni::client::download_source}"
 
     case $::osfamily {
       'Debian': {

--- a/manifests/client/params.pp
+++ b/manifests/client/params.pp
@@ -1,6 +1,7 @@
 # (private) defaults for omd::client
 class omd::client::params {
 
+  $download_source  = 'http://mathias-kettner.de/download'
   $download_package = true
   $logwatch_install = false
   $xinetd_disable   = 'no'


### PR DESCRIPTION
I tried to get package from mathias-kettner.de, but it returns 404, which turns my new check_mk client installation failed, looks like the version '1.2.4p5-1' is not available for check_mk agent, and there is no such policy to keep the existing one on the source path 'http://mathias-kettner.de/download', this way it is hard to maintain your running check_mk agents in same version, to fix this, have updated the code to keep the package locally (in puppet file store or any local http path). It still using the default url if argument not defined. 

staging::file supports multiple source location i.e. puppet://, http://, https://, ftp://, s3://

Error to download the package, now the available version is '1.2.4p5-2'

[ravi@host75 ~]$ wget http://mathias-kettner.de/download/check-mk-agent_1.2.4p5-1_all.deb
--2015-04-01 13:47:41--  http://mathias-kettner.de/download/check-mk-agent_1.2.4p5-1_all.deb
Resolving mathias-kettner.de (mathias-kettner.de)... 178.248.246.154
Connecting to mathias-kettner.de (mathias-kettner.de)|178.248.246.154|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2015-04-01 13:47:41 ERROR 404: Not Found.
