### PR TITLE
set rpm provider to ensure latest version

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -27,6 +27,7 @@ class omd::client::install {
         $pkg_source_agent    = "/opt/staging/omd/${pkg_agent}"
         $pkg_source_logwatch = "/opt/staging/omd/${pkg_logwatch}"
         $pkg_provider        = 'dpkg'
+        $pkg_ensure          = 'installed'
 
       }
       'RedHat': {
@@ -34,6 +35,7 @@ class omd::client::install {
         $pkg_source_agent    = "${download_source}/check_mk-agent-${omd::client::check_mk_version}.noarch.rpm"
         $pkg_source_logwatch = "${download_source}/check_mk-agent-logwatch-${omd::client::check_mk_version}.noarch.rpm"
         $pkg_provider        = 'rpm'
+        $pkg_ensure          = 'latest'
 
       }
       default: {
@@ -44,6 +46,7 @@ class omd::client::install {
     $pkg_source_agent    = undef
     $pkg_source_logwtach = undef
     $pkg_provider        = undef
+    $pkg_ensure          = 'installed'
   }
 
   # some packages (e.g. CentOS 7) do not create directory
@@ -55,7 +58,7 @@ class omd::client::install {
   }
 
   package { 'check_mk-agent':
-    ensure   => installed,
+    ensure   => $pkg_ensure,
     name     => $omd::client::package_name,
     source   => $pkg_source_agent,
     provider => $pkg_provider,
@@ -64,7 +67,7 @@ class omd::client::install {
 
   if $omd::client::logwatch_install {
     package { 'check_mk-agent-logwatch':
-      ensure   => installed,
+      ensure   => $pkg_ensure,
       name     => "${omd::client::package_name}-logwatch",
       source   => $pkg_source_logwatch,
       provider => $pkg_provider,


### PR DESCRIPTION
Unless the RPM provider gets 'ensure => latest' it will not update packages when the version
variable is bumped (even though the package name changes) - it sees some version installed, which qualifies. Setting to 'latest' for RPM to achieve expected behavior while leaving everything else as is (dpkg, default)
